### PR TITLE
Add Thai FTS benchmark harness vs Elasticsearch + README results

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ Its main purpose is:
 
 To enable PostgreSQL Full Text Search in Thai language (Due to Thai Language does not use spaces to separate words)
 
+## Performance
+
+Benchmarked against **Elasticsearch 8.15 with the built-in `thai` analyzer** on
+100,000 Thai Wikipedia articles, single Docker host, warm cache:
+
+| Metric | pg-search-thai | ES (thai analyzer) |
+|---|---|---|
+| Single-term query (p50 / p95) | **1.4 ms / 4.3 ms** | 5.7 ms / 18.9 ms |
+| Boolean AND (p50 / p95) | **1.6 ms / 5.8 ms** | 6.7 ms / 9.8 ms |
+| Boolean OR (p50 / p95) | **2.6 ms / 3.2 ms** | 6.1 ms / 9.6 ms |
+| Index size | **105 MB** | 427 MB |
+| Write → searchable lag | 0 ms (transactional) | ~1 s (refresh interval) |
+
+Full reproducible harness, methodology, and caveats: see [`bench/BENCHMARKS.md`](bench/BENCHMARKS.md)
+and [`bench/README.md`](bench/README.md).
+
 ## Prerequisite
 
 libthai, libiconv - this pg extension requires Thai word breaking functionality from the popular `LibThai` and libiconv.


### PR DESCRIPTION
## Summary

- Adds reproducible Docker harness in `bench/` comparing `pg-search-thai` against Elasticsearch 8.15 (`thai` analyzer) on 100K Thai Wikipedia articles.
- Generates `bench/BENCHMARKS.md` with indexing, query-latency (p50/p95/p99), and index-size numbers split by query kind (single / AND / OR).
- Adds a Performance section to `README.md` linking to the full report.

## Headline numbers

| Metric | pg-search-thai | ES (thai analyzer) |
|---|---|---|
| Single-term p50 / p95 | **1.4 / 4.3 ms** | 5.7 / 18.9 ms |
| Boolean AND p50 / p95 | **1.6 / 5.8 ms** | 6.7 / 9.8 ms |
| Boolean OR p50 / p95  | **2.6 / 3.2 ms** | 6.1 / 9.6 ms |
| Index size            | **105 MB**       | 427 MB |
| Write → searchable    | 0 ms (txn)       | ~1 s |

## Caveats (also documented in `bench/README.md`)

- Single host, single node, single client, warm cache. Don't extrapolate to multi-node clusters or heavy concurrency.
- ES `thai` analyzer is ICU-based; this extension uses libthai. Word-boundary disagreements are expected, not bugs.
- Top-10 hit counts match across all 50 probe queries — sanity-check passes; real recall would need labelled relevance.

## Test plan

- [x] `cd bench && make up && make corpus && make bench` reproduces results within ~10% on similar hardware
- [x] `BENCHMARKS.md` renders cleanly on GitHub
- [x] README links resolve to the right files
- [x] `make nuke` cleans up volumes + corpus